### PR TITLE
Fixes deprecations in HA 2024.1

### DIFF
--- a/tool/ovModbus.py
+++ b/tool/ovModbus.py
@@ -42,7 +42,7 @@ def get_hass_modbustcp_def(data):
 
 def get_hass_sensor_def(data):
     sensor_string = f"""
-        - name: "{data['description']}"         
+        - name: "{data['description']}"
           unique_id: ovum_{data['parameter']}_sensor{data['address']}
           address: {data['address']}
           scan_interval: 15                
@@ -54,17 +54,17 @@ def get_hass_sensor_def(data):
           input_type: holding
           min_value: {data['min_val']}
           max_value: {data['max_val']}
-          slave: {data['slave']}                    
+          slave: {data['slave']}
           {data['device_class']}"""
     return f"{sensor_string}"
 
 def get_hass_binsensor_def(data):
     sensor_string = f"""
-        - name: "{data['description']}"         
+        - name: "{data['description']}"
           unique_id: ovum_{data['parameter']}_sensor{data['address']}
           address: {data['address']}
-          lazy_error_count: 2                
-          scan_interval: 15                
+          lazy_error_count: 2
+          scan_interval: 15
           input_type: holding
           slave: {data['slave']}"""
     return f"{sensor_string}"
@@ -79,10 +79,10 @@ def get_hass_templatesensor_def(data):
               state: >
                 {{% set mapper =  {{
                     {data['map']}
-                    }} 
-                %}}            
-                {{% 
-                    set state =  states('{data['sensor']}') 
+                    }}
+                %}}
+                {{%
+                    set state =  states('{data['sensor']}')
                 %}}
                 {{{{ mapper[state] if state in mapper}}}}"""
     return f"{sensor_string}"

--- a/tool/ovModbus.py
+++ b/tool/ovModbus.py
@@ -45,7 +45,7 @@ def get_hass_sensor_def(data):
         - name: "{data['description']}"
           unique_id: ovum_{data['parameter']}_sensor{data['address']}
           address: {data['address']}
-          scan_interval: 15                
+          scan_interval: 15
           data_type: int32
           scale: {data['scale']}
           precision: {data['precision']}
@@ -63,7 +63,6 @@ def get_hass_binsensor_def(data):
         - name: "{data['description']}"
           unique_id: ovum_{data['parameter']}_sensor{data['address']}
           address: {data['address']}
-          lazy_error_count: 2
           scan_interval: 15
           input_type: holding
           slave: {data['slave']}"""


### PR DESCRIPTION
Full changelog: https://www.home-assistant.io/changelogs/core-2024.1

- `lazy_error_count` is deprecated https://github.com/home-assistant/core/pull/105037
- `retries` is deprecated https://github.com/home-assistant/core/pull/105024